### PR TITLE
Fix command line status error

### DIFF
--- a/lib/web_translate_it/project.rb
+++ b/lib/web_translate_it/project.rb
@@ -41,7 +41,7 @@ module WebTranslateIt
           request = Net::HTTP::Get.new("/api/projects/#{api_key}/stats.yaml")
           request.add_field("X-Client-Name", "web_translate_it")
           request.add_field("X-Client-Version", WebTranslateIt::Util.version)
-          Util.handle_response(http.request(request), true)
+          return Util.handle_response(http.request(request), true)
         end
       rescue Timeout::Error
         puts "Request timeout. Will retry in 5 seconds."


### PR DESCRIPTION
When you run `$ wti status` this error appears:

`# Gathering information on Test
.../lib/ruby/2.3.0/psych.rb:377:in 'parse': no implicit conversion of true into String (TypeError)
	from .../lib/ruby/2.3.0/psych.rb:377:in 'parse_stream'
	from .../lib/ruby/2.3.0/psych.rb:325:in 'parse'
	from .../lib/ruby/2.3.0/psych.rb:252:in 'load'
	from .../lib/ruby/gems/2.3.0/gems/web_translate_it-2.4.3/lib/web_translate_it/command_line.rb:249:in 'status'
	from .../lib/ruby/gems/2.3.0/gems/web_translate_it-2.4.3/lib/web_translate_it/command_line.rb:30:in 'initialize'
	from .../lib/ruby/gems/2.3.0/gems/web_translate_it-2.4.3/bin/wti:120:in 'new'
	from .../lib/ruby/gems/2.3.0/gems/web_translate_it-2.4.3/bin/wti:120:in '<top (required)>'
	from .../bin/wti:23:in 'load'
	from .../bin/wti:23:in '<main>'`


A simple `return` on `fetch_stats` response solves the problem.